### PR TITLE
Fix links to make markdown parser happy

### DIFF
--- a/Alchemist/README.md
+++ b/Alchemist/README.md
@@ -3,5 +3,5 @@
 The Alchemist is a micro synthesizer and effects unit based on the OWL2 board, designed and manufactured by Rebel Technology. The product page is [here](https://www.rebeltech.org/products/alchemist).
 
 ### Instructions
-* [Alchemist Getting Started](Alchemist_Getting_Started) (as [pdf](Alchemist Getting Started.pdf))
+* [Alchemist Getting Started](Alchemist_Getting_Started.md) (as [pdf](Alchemist%20Getting%20Started.pdf))
 

--- a/Magus/README.md
+++ b/Magus/README.md
@@ -3,6 +3,6 @@
 The Magus is a patchable synthesizer and effects unit based on the OWL2 board, designed and manufactured by Rebel Technology. The product page is [here](https://www.rebeltech.org/products/magus).
 
 ### Instructions
-* [Magus Desktop Getting Started](Magus_Desktop_Getting_Started) (as [pdf](Magus Desktop Getting Started.pdf))
-* [Magus Eurorack Getting Started](Magus_Eurorack_Getting_Started) (as [pdf](Magus Eurorack Getting Started.pdf))
+* [Magus Desktop Getting Started](Magus_Desktop_Getting_Started.md) (as [pdf](Magus%20Desktop%20Getting%20Started.pdf))
+* [Magus Eurorack Getting Started](Magus_Eurorack_Getting_Started.md) (as [pdf](Magus%20Eurorack%20Getting%20Started.pdf))
 

--- a/OWL_Modular/README.md
+++ b/OWL_Modular/README.md
@@ -3,5 +3,5 @@
 The OWL Modular is a Eurorack synthesizer and effects unit based on the legacy OWL board, designed and manufactured by Rebel Technology. The product page is [here](https://www.rebeltech.org/products/owl-modular).
 
 ### Instructions
-* [OWL Modular Getting Started](OWL_Modular_Getting_Started) (as [pdf](OWL Modular Getting Started v12.pdf))
+* [OWL Modular Getting Started](OWL_Modular_Getting_Started.md) (as [pdf](OWL%20Modular%20Getting%20Started%20v12.pdf))
 

--- a/OWL_Pedal/README.md
+++ b/OWL_Pedal/README.md
@@ -3,4 +3,4 @@
 The OWL Pedal is a  synthesizer and effects pedal based on the legacy OWL board, designed and manufactured by Rebel Technology. The product page is [here](https://www.rebeltech.org/products/owl-pedal).
 
 ### Instructions
-* [OWL Pedal Getting Started](OWL_Pedal_Getting_Started) (as [pdf](OWL Pedal Getting Started v12.pdf))
+* [OWL Pedal Getting Started](OWL_Pedal_Getting_Started.md) (as [pdf](OWL%20Pedal%20Getting%20Started%20v12.pdf))

--- a/Wizard/README.md
+++ b/Wizard/README.md
@@ -3,5 +3,5 @@
 The Wizard is a mini synthesizer and effects unit based on the OWL2 board, designed and manufactured by Rebel Technology. The product page is [here](https://www.rebeltech.org/products/wizard).
 
 ### Instructions
-* [Wizard Getting Started](Wizard_Getting_Started) (as [pdf](Wizard Getting Started.pdf))
+* [Wizard Getting Started](Wizard_Getting_Started.md) (as [pdf](Wizard%20Getting%20Started.pdf))
 


### PR DESCRIPTION
Links to MD format docs didn't have .md extension in URLs. PDFs didn't use hex escaping (this breaks markdown parser at least in github). 